### PR TITLE
support webhook in any part of the path

### DIFF
--- a/HTTPd2.indigoPlugin/Contents/Info.plist
+++ b/HTTPd2.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/HTTPd2.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HTTPd2.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -203,7 +203,7 @@ class MyRequestHandler(BaseHTTPRequestHandler):
         if request.path == "/setvar":
             self.do_setvar(request)
         
-        elif request.path.startswith("/webhook"):
+        elif "webhook" in request.path:
             self.do_webhook(request)
         
         else:
@@ -228,7 +228,7 @@ class MyRequestHandler(BaseHTTPRequestHandler):
         if request.path == "/setvar":
             self.do_setvar(request)
 
-        elif request.path.startswith("/webhook"):
+        elif "webhook" in request.path:
             self.do_webhook(request)
                 
         else:


### PR DESCRIPTION
Instead of listening only for /webook, listens for /*webhook*, allowing more flexibility for webhook urls that can't be simply "/webook"